### PR TITLE
TOC generated separately

### DIFF
--- a/org-mode-lucid/CHANGELOG.md
+++ b/org-mode-lucid/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 1.5.0 (2020-09-04)
+
+#### Added
+
+- `toc` function is now exposed for manually generating an article's associated
+  Table of Contents.
+
+#### Changed
+
+- Tables of Contents are no longer automatically injected into the `Html`
+  produced by the `html` and `body` functions.
+- The `tableOfContents` field of `OrgStyle` is no longer a `Maybe`. It must be
+  provided, but can be given any value if you don't intend to call `toc`
+  yourself.
+
+#### Removed
+
+- The `TOC` type had its `tocTitle :: Text` field removed.
+
 ## 1.4.0 (2020-07-13)
 
 #### Added

--- a/org-mode-lucid/org-mode-lucid.cabal
+++ b/org-mode-lucid/org-mode-lucid.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               org-mode-lucid
-version:            1.4.0
+version:            1.5.0
 synopsis:           Lucid integration for org-mode.
 description:        Lucid integration for org-mode.
 category:           Web


### PR DESCRIPTION
This is so that the caller has more freedom over where the TOC is injected into the final `Html` structure.