### PR TITLE
TODOs and Priority

### DIFF
--- a/org-mode-lucid/lib/Data/Org/Lucid.hs
+++ b/org-mode-lucid/lib/Data/Org/Lucid.hs
@@ -120,7 +120,7 @@ toc' os t depth (OrgDoc _ ss)
   | otherwise = ul_ $ traverse_ f ss
   where
     f :: Section -> Html ()
-    f (Section ws _ _ _ _ _ _ od) = do
+    f (Section _ _ ws _ _ _ _ _ _ od) = do
       li_ $ a_ [href_ $ "#" <> tocLabel ws] $ paragraphHTML os ws
       toc' os t (succ depth) od
 
@@ -134,7 +134,7 @@ orgHTML' os depth (OrgDoc bs ss) = do
 
 -- | Section timestamps and properties are ignored.
 sectionHTML :: OrgStyle -> Int -> Section -> Html ()
-sectionHTML os depth (Section ws _ _ _ _ _ _ od) = sectionStyling os depth theHead theBody
+sectionHTML os depth (Section _ _ ws _ _ _ _ _ _ od) = sectionStyling os depth theHead theBody
   where
     theHead :: Html ()
     theHead = heading [id_ $ tocLabel ws] $ paragraphHTML os ws

--- a/org-mode/CHANGELOG.md
+++ b/org-mode/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-This release sees the extension of this library to understand heading timestamps
-and `PROPERTIES` drawers.
+This release sees the extension of this library to understand heading
+timestamps, TODOs, priorities, and `PROPERTIES` drawers.
 
 #### Added
 

--- a/org-mode/test/Test.hs
+++ b/org-mode/test/Test.hs
@@ -113,7 +113,7 @@ suite simple full = testGroup "Unit Tests"
                              , dateDayOfWeek = Monday
                              , dateTime = Just $ OrgTime (TimeOfDay 15 43 0) Nothing
                              , dateRepeat = Nothing }
-        in OrgDoc [] [ Section [Plain "A"] [] (Just cl) (Just dl) Nothing Nothing mempty (OrgDoc [ Paragraph [Plain "D"]] []) ]
+        in OrgDoc [] [ Section Nothing Nothing [Plain "A"] [] (Just cl) (Just dl) Nothing Nothing mempty (OrgDoc [ Paragraph [Plain "D"]] []) ]
 
     , testCase "Header - Empty Properties Drawer"
       $ testPretty orgP "Header" "* A\n  :PROPERTIES:\n  :END:"

--- a/org-mode/test/Test.hs
+++ b/org-mode/test/Test.hs
@@ -43,6 +43,21 @@ suite simple full = testGroup "Unit Tests"
       [ (titled (Plain "A")) { sectionDoc = OrgDoc [Paragraph [Plain "D"]] [ titled (Plain "B") ] }
       , titled (Plain "C") ]
 
+    , testCase "Header - TODO"
+      $ testPretty orgP "Header" "* TODO A"
+      $ OrgDoc []
+      [ (titled (Plain "A")) { sectionTodo = Just TODO }]
+
+    , testCase "Header - Priority"
+      $ testPretty orgP "Header" "* [#A] A"
+      $ OrgDoc []
+      [ (titled (Plain "A")) { sectionPriority = Just $ Priority "A" }]
+
+    , testCase "Header - TODO + Priority"
+      $ testPretty orgP "Header" "* TODO [#A] A"
+      $ OrgDoc []
+      [ (titled (Plain "A")) { sectionTodo = Just TODO, sectionPriority = Just $ Priority "A" }]
+
     , testCase "Header - One line, single tag"
       $ testPretty orgP "Header" "* A  :this:"
       $ OrgDoc [] [ (titled (Plain "A")) { sectionTags = ["this"] } ]


### PR DESCRIPTION
This PR extends the types and parser to account for `TODO` markings and their priorities.
